### PR TITLE
Fix bug with signal testing, add decimal parsing

### DIFF
--- a/include/plusone/impl/parse.ipp
+++ b/include/plusone/impl/parse.ipp
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <plusone/expect.hpp>
+#include <plusone/compiler.hpp>
+#include <plusone/math.hpp>
+#include <plusone/exception.hpp>
+
+namespace plusone {
+namespace detail {
+
+struct parse_result
+{
+    std::uint64_t value{0};
+    bool sign{true};
+    unsigned count{0};
+};
+
+__force_inline void parse_reverse_while_digit(const char* data, std::size_t size, parse_result& result) noexcept
+{
+    result = {};
+
+    const char* cur = data + size;
+    for (; result.count < size; ++result.count) {
+        --cur;
+        if (__unlikely((*cur < '0') || (*cur > '9'))) {
+            if (*cur == '-') {
+                result.sign = false;
+                ++result.count;
+            } else if (*cur == '+') {
+                /* sign already true. */
+                ++result.count;
+            }
+            break;
+        } else {
+            result.value += static_cast< std::uint8_t >(*cur - '0') * pow10::get(result.count);
+        }
+    }
+}
+
+__force_inline std::int64_t apply_sign(std::int64_t value, bool sign) noexcept
+{
+    return sign ? value : -value;
+}
+
+__force_inline std::int64_t apply_pow(std::int64_t value, unsigned e) noexcept
+{
+    return value * pow10::get(e);
+}
+
+__force_inline constexpr std::int64_t apply(std::int64_t value, bool sign, unsigned p) noexcept
+{
+    auto res = value * pow10::get(p);
+    return sign ? res : -res;
+}
+
+__force_inline std::pair< std::int64_t, bool > parse_decimal8(const char* data, std::size_t size) noexcept
+{
+    static constexpr auto error = std::make_pair< std::int64_t, bool >(0, false);
+
+    if (__unlikely(size == 0)) {
+        return error;
+    }
+
+    parse_result result;
+    parse_reverse_while_digit(data, size, result);
+    if (size == result.count) {
+        return {apply(result.value, result.sign, 8), true};
+    }
+    size -= (result.count + 1);
+
+    if (__likely(data[size] == '.')) {
+        if (__unlikely(result.count > 8 || !result.sign)) {
+            return error;
+        }
+        auto short_part = apply(result.value, true, 8 - result.count);
+
+        parse_reverse_while_digit(data, size, result);
+        if (__likely(size == result.count)) {
+            return {apply_sign(apply_pow(result.value, 8) + short_part, result.sign), true};
+        }
+    } else if (__likely(data[size] == 'e')) {
+        int p = result.sign ? result.value : -result.value;
+
+        parse_reverse_while_digit(data, size, result);
+        if (size == result.count) {
+            p += 8;
+            if (__unlikely(p >= static_cast< int >(pow10::table_size) || p < 0)) {
+                return error;
+            }
+            return {apply(result.value, result.sign, p), true};
+        }
+
+        size -= (result.count + 1);
+
+        if (__unlikely(data[size] != '.')) {
+            return error;
+        }
+
+        if (__unlikely(!result.sign)) {
+            return error;
+        }
+
+        p = p - result.count + 8;
+        if (__unlikely(p < 0 || p >= static_cast< int >(pow10::table_size))) {
+            return error;
+        }
+
+        auto short_part = apply(result.value, true, p);
+        p += result.count;
+
+        if (__unlikely(p >= static_cast< int >(pow10::table_size))) {
+            return error;
+        }
+
+        parse_reverse_while_digit(data, size, result);
+        if (__unlikely(size != result.count)) {
+            return error;
+        }
+
+        return {apply_sign(apply_pow(result.value, p) + short_part, result.sign), true};
+    }
+
+    return error;
+}
+} /* namespace detail */
+
+__force_inline std::int64_t parse_positive_decimal8(const string_view& str)
+{
+    auto result = detail::parse_decimal8(str.data(), str.size());
+    if (__unlikely(!result.second || result.first < 0)) {
+        throw_ex< std::runtime_error >("Not a positive decimal8 ({})", str);
+    }
+    return result.first;
+}
+
+__force_inline std::int64_t parse_decimal8(const string_view& str)
+{
+    auto result = detail::parse_decimal8(str.data(), str.size());
+    if (__unlikely(!result.second)) {
+        throw_ex< std::runtime_error >("Not a decimal8 ({})", str);
+    }
+    return result.first;
+}
+
+} /* namespace plusone */

--- a/include/plusone/parse.hpp
+++ b/include/plusone/parse.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include "math.hpp"
+
+namespace plusone {
+
+/** Parse positive decimal8 string as number 
+ E.g. : 2.1458e2, 22.1458
+ */
+std::int64_t parse_positive_decimal8(const string_view& str);
+
+/** Parse decimal8 string as number 
+ E.g. : -2.1458e2, 22.1458
+ */
+std::int64_t parse_decimal8(const string_view& str);
+
+} /* namespace plusone */
+
+#include <plusone/impl/parse.ipp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,10 @@ add_executable(math_test math.cpp)
 target_link_libraries(math_test plusone doctest)
 add_test(math math_test)
 
+add_executable(parse_test parse.cpp)
+target_link_libraries(parse_test plusone doctest)
+add_test(parse parse_test)
+
 add_executable(socket_test socket.cpp)
 target_link_libraries(socket_test plusone doctest)
 add_test(socket socket_test)

--- a/tests/parse.cpp
+++ b/tests/parse.cpp
@@ -1,0 +1,43 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest.h>
+#include <plusone/string_view.hpp>
+#include <plusone/parse.hpp>
+
+using plusone::string_view;
+using namespace plusone::string_view_literals;
+
+TEST_CASE("Parse positive decimal")
+{
+    auto v1 = plusone::parse_positive_decimal8("10"sv);
+    auto v2 = plusone::parse_positive_decimal8("0.123"sv);
+    auto v3 = plusone::parse_positive_decimal8("9e2"sv);
+    auto v4 = plusone::parse_positive_decimal8("3e-2"sv);
+    auto v5 = plusone::parse_positive_decimal8("9.5e4"sv);
+    auto v6 = plusone::parse_positive_decimal8("3.112e-3"sv);
+
+    REQUIRE(v1 == 1000000000ul);
+    REQUIRE(v2 == 12300000ul);
+    REQUIRE(v3 == 90000000000ul);
+    REQUIRE(v4 == 3000000ul);
+    REQUIRE(v5 == 9500000000000ul);
+    REQUIRE(v6 == 311200ul);
+}
+
+TEST_CASE("Parse signed decimal8")
+{
+    auto v1 = plusone::parse_decimal8("-10"sv);
+    auto v2 = plusone::parse_decimal8("0.123"sv);
+    auto v3 = plusone::parse_decimal8("9e2"sv);
+    auto v4 = plusone::parse_decimal8("-3e-2"sv);
+    auto v5 = plusone::parse_decimal8("-9.5e4"sv);
+    auto v6 = plusone::parse_decimal8("3.112e-3"sv);
+	auto v7 = plusone::parse_decimal8("0"sv);
+
+    REQUIRE(v1 == -1000000000l);
+    REQUIRE(v2 == 12300000l);
+    REQUIRE(v3 == 90000000000l);
+    REQUIRE(v4 == -3000000l);
+    REQUIRE(v5 == -9500000000000l);
+    REQUIRE(v6 == 311200l);
+    REQUIRE(v7 == 0);
+}

--- a/tests/signal.cpp
+++ b/tests/signal.cpp
@@ -13,11 +13,11 @@ TEST_CASE("Signal base")
     auto handler1 = plusone::signal::get_handler(SIGINT);
     auto handler2 = plusone::signal::get_handler(SIGINT);
     REQUIRE( handler1 == handler2 );
-
+    
     plusone::signal::set_handler(SIGINT, test);
     auto handler3 = plusone::signal::get_handler(SIGINT);
     REQUIRE( handler3 != handler1 );
-    REQUIRE( handler3 == test );
+    REQUIRE( handler3 == &test );
 
     plusone::signal::set_handler(SIGINT, SIG_DFL);
     auto handler4 = plusone::signal::get_handler(SIGINT);
@@ -26,4 +26,5 @@ TEST_CASE("Signal base")
     plusone::signal::set_handler(SIGINT, SIG_IGN);
     auto handler5 = plusone::signal::get_handler(SIGINT);
     REQUIRE( handler5 == SIG_IGN );
+    
 }


### PR DESCRIPTION
1. Add decimal-like strings parsing (maybe useful). Supported formats: (2.145e-2, -22.1458)
2. Fix broken signal test case